### PR TITLE
Properly deal with empty lines

### DIFF
--- a/LinkOpener.pm
+++ b/LinkOpener.pm
@@ -8,6 +8,7 @@ sub get_links {
     open(my $fh, '<', $link_data) || die("Unable to open file ($link_data) for read: $!\n");
     while (my $line = <$fh>) {
         chomp($line);
+        next unless $line; # don't process blank lines
         my ($link, $alias, $count) = split(/\|/, $line);
         $links{$link} = {
             link => $link,
@@ -33,7 +34,8 @@ sub add_url {
     my ($url, $name) = @_;
     $name ||= '';
     open(my $fh, '>>', $link_data) || die("Unable to open file ($link_data) for append: $!\n");
-    print $fh join($sep, $url, $name) . "\n";
+    # extra \n incase someone removed the last empty line
+    print $fh "\n" . join($sep, $url, $name) . "\n";
     close($fh);
 }
 

--- a/info.plist
+++ b/info.plist
@@ -360,7 +360,7 @@ perl linkopener.pl "$query" 2&gt;&amp;1</string>
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>0.0.6</string>
+	<string>0.0.8</string>
 	<key>webaddress</key>
 	<string>https://github.com/skeletonkey/link_opener</string>
 </dict>


### PR DESCRIPTION
Skip empty lines as they produce errors.
While inserting add an extra \n so that a new isn't simply added to the end of the last link.