### PR TITLE
Enable "long names"

### DIFF
--- a/LinkOpener.pm
+++ b/LinkOpener.pm
@@ -31,7 +31,8 @@ sub save_data {
 }
 
 sub add_url {
-    my ($url, $name) = @_;
+    my $url = shift;
+    my $name = join(" ", @_);
     $name ||= '';
     open(my $fh, '>>', $link_data) || die("Unable to open file ($link_data) for append: $!\n");
     # extra \n incase someone removed the last empty line

--- a/info.plist
+++ b/info.plist
@@ -143,7 +143,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>keyword</key>
-				<string>link</string>
+				<string>l</string>
 				<key>queuedelaycustom</key>
 				<integer>3</integer>
 				<key>queuedelayimmediatelyinitially</key>


### PR DESCRIPTION
Names now can contain spaces.

Changed keyword to 'l' to stop accidentally triggering add or edit.